### PR TITLE
Update ciphey.py

### DIFF
--- a/ciphey/ciphey.py
+++ b/ciphey/ciphey.py
@@ -252,16 +252,18 @@ def main(**kwargs):
         raise TypeError(f"Cannot load type {config.format} from {type(kwargs['text'])}")
 
     result: Optional[str]
-
+                        
     # if debug or quiet mode is on, run without spinner
-    if config.verbosity != 0:
-        result = decrypt(config, kwargs["text"])
-    else:
-        # else, run with spinner if verbosity is 0
-        with yaspin(Spinners.earth, "Thinking") as sp:
-            config.set_spinner(sp)
+    try:
+        if config.verbosity != 0:
             result = decrypt(config, kwargs["text"])
-    if result is None:
-        result = "Could not find any solutions."
-
-    print(result)
+        else:
+            # else, run with spinner if verbosity is 0
+            with yaspin(Spinners.earth, "Thinking") as sp:
+                config.set_spinner(sp)
+                result = decrypt(config, kwargs["text"])
+        if result is None:
+            result = "Could not find any solutions."
+        print(result)
+    except KeyboardInterrupt:
+        sys.exit()


### PR DESCRIPTION
so people can't exit ciphey so just added KeyboardInteruption does this make sense? 

here are some screenshots and stuff to make it look bjutiful when people are looking at this pool request 

_so here is the issue when i "exit" it it doesn't really exit it look at the first scerenshot _ 
![Screenshot_2020-11-02_04-39-32](https://user-images.githubusercontent.com/61194758/97846054-58553600-1ce5-11eb-8d6c-fdcac5e292e6.png)
so now that i have apperently exited even tho it stays and runs in the background i have to manually exit it with **_SIGKILL_**
![Screenshot_2020-11-02_04-38-34](https://user-images.githubusercontent.com/61194758/97846169-863a7a80-1ce5-11eb-8fdd-a3664e52d4b2.png)
![Screenshot_2020-11-02_04-39-14](https://user-images.githubusercontent.com/61194758/97846178-89356b00-1ce5-11eb-96ff-4c15959d5292.png)
just killed it and then it exited